### PR TITLE
feat:VisitHistory(HistoryInfo) localStorage function implemented

### DIFF
--- a/src/components/HistoryInfo.jsx
+++ b/src/components/HistoryInfo.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Link, useNavigate } from 'react-router-dom';
 
@@ -13,34 +13,40 @@ const HistoryBox = styled.div`
   width: 1000px;
   height: 30px;
   background-color: #fbfffa;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); 
-  border-radius: 8px; 
-  padding: 16px; 
-  margin: 16px 0; 
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  padding: 16px;
+  margin: 16px 0;
 `;
 
-const TitleText=styled.div`
+const TitleText = styled.div`
   font-size: 20px;
   font-weight: bold;
-  left: 20px; 
-
-`
+  left: 20px;
+`;
 export default function HistoryInfo() {
-  const navigate=useNavigate();
-  const historyItems = ['title1','title2','title3','title4','title5','title6','title7','title8','title9']; // 임의 배열!
-
-  const handleClick= (title)=>{
+  const navigate = useNavigate();
+  const [history, setHistory] = useState(JSON.parse(sessionStorage.getItem('history')));
+  const handleClick = (title) => {
     navigate(`/AuctionDetail/${title}`);
   }; //주소 이동
 
   return (
     <>
       <WrapHistory>
-        {historyItems.map((title,index) => (
-          <HistoryBox key={index} onClick={()=>handleClick(title)}>
-            <TitleText>{title}</TitleText>
-          </HistoryBox>  
+        {history.map((id, index) => (
+          <HistoryBox key={index} onClick={() => handleClick(id)}>
+            <TitleText>{id}</TitleText>
+          </HistoryBox>
         ))}
+        <button
+          onClick={() => {
+            sessionStorage.setItem('history', JSON.stringify([]));
+            setHistory([]);
+          }}
+        >
+          Clear History
+        </button>
       </WrapHistory>
     </>
   );

--- a/src/pages/AuctionDetail.jsx
+++ b/src/pages/AuctionDetail.jsx
@@ -21,12 +21,23 @@ export default function AuctionDetail() {
   ]);
   const { auctionId } = useParams();
 
-  // useEffect(() => {
-  //   axios
-  //     .get('')
-  //     .then((res) => setTenders(res.data))
-  //     .catch((e) => console.log(e));
-  // }, []);
+  useEffect(() => {
+    //   axios
+    //     .get('')
+    //     .then((res) => setTenders(res.data))
+    //     .catch((e) => console.log(e));
+    saveHistory(auctionId);
+  }, []);
+
+  const saveHistory = (tmpId) => {
+    var arr = sessionStorage.getItem('history');
+    arr = JSON.parse(arr);
+
+    arr.push(tmpId);
+    arr = new Set(arr);
+    arr = [...arr];
+    sessionStorage.setItem('history', JSON.stringify(arr));
+  };
 
   const deleteTender = (id) => {
     setTenders(tenders.filter((tender) => tender.id !== id));

--- a/src/pages/AuctionLists.jsx
+++ b/src/pages/AuctionLists.jsx
@@ -1,27 +1,29 @@
-import React from 'react';
-import AuctionList from "../components/AuctionList";
+import React, { useEffect } from 'react';
+import AuctionList from '../components/AuctionList';
 import styled from 'styled-components';
 import { useParams } from 'react-router-dom';
 
-
 const Container = styled.div`
   height: 1000px;
-`
+`;
 
-const AuctionLists =() => {
-  
+const AuctionLists = () => {
   const { keyword } = useParams();
 
-  
-  return(
-      <>
+  useEffect(() => {
+    if (sessionStorage.getItem('history') === null) {
+      sessionStorage.setItem('history', JSON.stringify([]));
+    }
+  }, []);
+
+  return (
+    <>
       <div>{keyword}</div>
       <Container>
-      <AuctionList></AuctionList>
+        <AuctionList />
       </Container>
-      </>
+    </>
   );
 };
-
 
 export default AuctionLists;


### PR DESCRIPTION
![History LocalStorage](https://github.com/Likelion-ADvise/ADvise-FE/assets/87813995/ae2b7e50-e35b-4158-a3ca-30fbaa0b68ae)
sessionStorage 를 사용해 기존에 유저들이 들어가봤던 게시글들을 보여주는 history 기능을 만들었습니다.
- AuctionDetail/{AuctionId} 위치로 들어가면 AuctionId 를 저장해 history에 보여주는 기능입니다.
- history를 누르면 해당 AuctionDetail 페이지로 넘어가게 됩니다.
- 추가적으로 clear History 를 누를시 history가 초기화 됩니다.

추가적으로 아직 VisitHistory에 위치해야 하는 함수들이 HistoryInfo에 위치해 있어 VisitHistory에 적어야 하는 함수들을 임의로 _**HistoryInfo에 적어둔 상태이니 꼭 꼭 확인후 수정해주시면 감사합니다**_!